### PR TITLE
Fix "import * as ... from ..." imports

### DIFF
--- a/transformer.ts
+++ b/transformer.ts
@@ -58,7 +58,7 @@ function visitSourceFile(sourceFile: ts.SourceFile, context: ts.TransformationCo
   }
 
   function isImportExportSpecifierRelative(node: ImportExportNode) {
-    if (node.moduleSpecifier) {
+    if (node.moduleSpecifier && node.moduleSpecifier.getSourceFile()) {
       return isPathRelative(getModuleSpecifierValue(node.moduleSpecifier))
     }
     return false
@@ -75,7 +75,7 @@ function visitSourceFile(sourceFile: ts.SourceFile, context: ts.TransformationCo
   }
 
   function relativizeImportExportNode(node: ImportExportNode, sourceFilePath: string) {
-    if (!node.moduleSpecifier) {
+    if (!node.moduleSpecifier || !node.moduleSpecifier.getSourceFile()) {
       return node
     }
 


### PR DESCRIPTION
Hi,
I was trying your module and I got a nasty error when running webpack:
```
undefined:83296
                throw e;
                ^

TypeError: Cannot read property 'text' of undefined
    at TokenObject.TokenOrIdentifierObject.getText 
```
After close inspection it happened for `import * as ... from ...` cases and I could find that in those cases a `node` did have a `moduleSpecifier`, but with `getSourceFile` returning `undefined`, leading to the error.

The changes in this PR fix the issue for me. I'm not familiar with those node objects and how they should work though, so I'd like to know if you find the fix to be correct.