### PR TITLE
Don't combine with current dir if baseUrl already an absolute path

### DIFF
--- a/transformer.ts
+++ b/transformer.ts
@@ -19,7 +19,7 @@ type ImportExportNode = ts.ExportDeclaration | ts.ImportDeclaration
 
 const transformerFactory: ts.TransformerFactory<ts.SourceFile> = context => {
   const compilerOptions = context.getCompilerOptions()
-  const absoluteBaseUrl = nodePath.join(process.cwd(), compilerOptions.baseUrl || '.');
+  const absoluteBaseUrl = compilerOptions.baseUrl && compilerOptions.baseUrl[0] === '/' ? compilerOptions.baseUrl : nodePath.join(process.cwd(), compilerOptions.baseUrl || '.');
   const matchPathFunc = createMatchPath(absoluteBaseUrl, compilerOptions.paths || {});
 
   return file => visitSourceFile(file, context, matchPathFunc) as ts.SourceFile;


### PR DESCRIPTION
If baseUrl is set to an absolute path (in the latest version of typescript relative pathing of baseUrl is turned into an absolute path) combining with cwd breaks the transform. This won't combine with cwd if baseUrl is already an absolute path.