### PR TITLE
Fix crash in watch mode

### DIFF
--- a/transformer.ts
+++ b/transformer.ts
@@ -90,12 +90,12 @@ function visitSourceFile(
 
   function getModuleSpecifierValue(specifier: ts.Expression) {
     // it's hard, so we'll just assume leading width is the length of the trailing width
-    const value = specifier
-      .getText()
-      .substr(
-        specifier.getLeadingTriviaWidth(),
-        specifier.getWidth() - specifier.getLeadingTriviaWidth() * 2
-      );
+    const value = (
+      ((specifier as unknown) as { text: string }).text || ""
+    ).substr(
+      specifier.getLeadingTriviaWidth(),
+      specifier.getWidth() - specifier.getLeadingTriviaWidth() * 2
+    );
     return value;
   }
 


### PR DESCRIPTION
Taking a cue from https://github.com/zerkalica/zerollup/commit/9f3cc5cf8fe2325e91cb15a8a23b6de88798f185, we won't call `.getText()` on module specifiers but just get the `text` property directly.